### PR TITLE
Update to mui 0.14.0 rc2

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -155,7 +155,7 @@
       }
     },
     "material-ui": {
-      "version": "0.13.4",
+      "version": "0.14.0-rc2",
       "dependencies": {
         "inline-style-prefixer": {
           "version": "0.5.4",
@@ -170,7 +170,7 @@
                   "version": "1.0.1"
                 },
                 "caniuse-db": {
-                  "version": "1.0.30000374"
+                  "version": "1.0.30000377"
                 },
                 "lodash.memoize": {
                   "version": "2.4.1",
@@ -256,13 +256,15 @@
           }
         },
         "lodash.throttle": {
-          "version": "3.0.4"
-        },
-        "lodash.debounce": {
-          "version": "3.1.1",
+          "version": "3.0.4",
           "dependencies": {
-            "lodash._getnative": {
-              "version": "3.9.1"
+            "lodash.debounce": {
+              "version": "3.1.1",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.1"
+                }
+              }
             }
           }
         },
@@ -346,7 +348,7 @@
               }
             },
             "ua-parser-js": {
-              "version": "0.7.9"
+              "version": "0.7.10"
             },
             "whatwg-fetch": {
               "version": "0.9.0"

--- a/package.js
+++ b/package.js
@@ -1,14 +1,17 @@
 Package.describe({
-  name: 'markoshust:material-ui',
-  version: '0.13.4',
-  summary: 'Package that contains the React implementation of Google Material Design',
-  git: 'https://github.com/markoshust/meteor-material-ui',
+  name: 'dcsan:material-ui',
+  version: '0.14.0',
+  summary: 'React + Material Design. using mui 0.14.0-rc2',
+  git: 'https://github.com/dcsan/meteor-material-ui',
   documentation: 'README.md'
 });
 
+// https://github.com/callemall/material-ui/blob/master/package.json
+// https://github.com/callemall/material-ui/blob/master/CHANGELOG.md
+
 Npm.depends({
   'externalify': '0.1.0',
-  'material-ui': '0.13.4',
+  'material-ui': '0.14.0-rc2',
   'react-tap-event-plugin': '0.2.1'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: 'dcsan:material-ui',
+  name: 'dcsan:mui',
   version: '0.14.0',
   summary: 'React + Material Design. using mui 0.14.0-rc2',
   git: 'https://github.com/dcsan/meteor-material-ui',


### PR DESCRIPTION
updated to use the latest upstream material-ui 0.14.0-rc2

however they had breaking changes on the menu and menuItems components
https://github.com/callemall/material-ui/pull/2307

I created a new demo repo here that shows how to use them (as I had to figure this out myself)
https://github.com/dcsan/react-hot
